### PR TITLE
cookie path, add auth.login to handler.authBasic, pass options to auth

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -156,7 +156,10 @@ AccountsApiHandler.prototype.authBasic = function (req, res, opts) {
         var payload = { key: account.key }
         if (account.admin) payload.admin = true
         var token = self.auth.tokens.sign(req, payload)
-        response().json({ token: token }).pipe(res)
+        self.auth.login(req, res, account, function (err, data) {
+          if (err) return errorResponse(res, 500, err)
+          return response().status(200).json({ token: token }).pipe(res)
+        })
       })
   })
 }

--- a/index.js
+++ b/index.js
@@ -1,8 +1,18 @@
+var extend = require('extend')
+
 module.exports = function (options) {
   options = options || {}
 
   return function (server) {
     var model = require('./model')(server.db, options)
+
+    var secret = options.secret
+    delete options.secret
+
+    var handlerOptions = extend(options, {
+      auth: require('./lib/auth')(secret, options)
+    })
+
     var handler = require('./handler')(model, options)
     var routes = require('./routes')(handler, options)
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -28,7 +28,7 @@ module.exports = function (secret, options) {
 
   auth.login = function (req, res, account, cb) {
     var token = tokens.sign(req, { key: account.key })
-    res.setHeader('Set-Cookie', 'access_token=' + token)
+    res.setHeader('Set-Cookie', 'access_token=' + token + '; ' + 'path=/; ')
     return cb(null, { session: token })
   }
 


### PR DESCRIPTION
i found i needed to set the cookie path to get it to stick around in the browser.

also got auth.login working in the basic auth handler.

also made it so we can pass the secret down to the auth module.
