### PR TITLE
add auth.logout, handler.logout. return key in successful basicAuth response

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -152,7 +152,7 @@ AccountsApiHandler.prototype.authBasic = function (req, res, opts) {
       if (err) return cb(err)
       self.auth.login(req, res, account, function (err, token) {
         if (err) return errorResponse(res, 500, err)
-        return response().status(200).json({ token: token }).pipe(res)
+        return response().status(200).json({ token: token, key: account.key }).pipe(res)
       })
     })
   })
@@ -161,6 +161,12 @@ AccountsApiHandler.prototype.authBasic = function (req, res, opts) {
 AccountsApiHandler.prototype.authItem = function (req, res, opts) {
   var login = opts.params.login // ie 'twitter', 'facebook', etc
   // TODO: Finish this
+}
+
+AccountsApiHandler.prototype.logout = function (req, res, opts) {
+  this.auth.logout(res)
+  res.writeHead(302, { 'Location': '/' })
+  return res.end()
 }
 
 /*

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -28,12 +28,9 @@ module.exports = function (secret, options) {
     return cb(null, token)
   }
 
-  auth.logout = function (req, res, cb) {
-    // TODO
-  }
-
-  auth.delete = function (req, cb) {
-    // TODO
+  auth.logout = 
+  auth.delete = function (res) {
+    res.setHeader('Set-Cookie', 'access_token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT')
   }
 
   auth.handle = function (req, res, cb) {

--- a/routes.js
+++ b/routes.js
@@ -6,7 +6,7 @@ module.exports = function (handler, options) {
   router.on(prefix + '/accounts/:key', handler.item.bind(handler))
   router.on(prefix + '/auth', handler.authBasic.bind(handler))
   router.on(prefix + '/auth/:login', handler.authItem.bind(handler))
-  router.on(prefix + '/auth/logout', handler.authItem.bind(handler))
+  router.on(prefix + '/auth/logout', handler.logout.bind(handler))
 
   return router
 }


### PR DESCRIPTION
i made `auth.logout` an alias to `auth.delete` for now.

not sure if it makes sense or not, but i've been finding it useful to have the account key returned along with the token in the successful basic auth response, so i added that as well.
