### PR TITLE
v1.0.0, use standard, examples, api client, simplify module.exports, cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 npm-debug.log
+tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - '5.0'
-  - 'iojs'
+  - '4.2'
   - 'stable'
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -14,16 +14,15 @@ To use it, you'd include it in the server like this:
 ```
 var http = require('http')
 var response = require('response')
-var levelup = require('levelup')
-var db = levelup('db', { db: require('memdown') })
+var level = require('level')
+var db = level('db')
+var accounts = require('accounts-api')(db)
 
 var server = http.createServer(function (req, res) {
   /* 
   * if req.url matches a route, it will return, 
   * otherwise, another part of the application can respond 
   */
-  this.db = db
-  var accounts = requires('accounts-api')(this)
   if (accounts.serve(req, res)) return
   response().json({ message: 'hi' }).pipe(res)
 })

--- a/client/accounts.js
+++ b/client/accounts.js
@@ -1,0 +1,34 @@
+var cuid = require('cuid')
+
+module.exports = Accounts
+
+function Accounts (client) {
+  if (!(this instanceof Accounts)) return new Accounts(client)
+  this.client = client
+}
+
+Accounts.prototype.get = function (username, options, cb) {
+  return this.client.request('get', 'accounts/' + username, options, cb)
+}
+
+Accounts.prototype.list = function (options, cb) {
+  return this.client.request('get', 'accounts', options, cb)
+}
+
+Accounts.prototype.create = function (options, cb) {
+  options.key = options.key || cuid()
+  return this.client.request('post', 'accounts', options, cb)
+}
+
+Accounts.prototype.update = function (username, options, cb) {
+  if (typeof username === 'object') {
+    cb = options
+    options = username
+    username = options.username
+  }
+  return this.client.request('put', 'accounts/' + username, options, cb)
+}
+
+Accounts.prototype.delete = function (username, cb) {
+  return this.client.request('delete', 'accounts/' + username, {}, cb)
+}

--- a/client/auth.js
+++ b/client/auth.js
@@ -1,0 +1,24 @@
+module.exports = Auth
+
+function Auth (client) {
+  if (!(this instanceof Auth)) return new Auth(client)
+  this.client = client
+}
+
+Auth.prototype.login = function (options, cb) {
+  var self = this
+  this.client.request('post', 'auth', options, function (err, res) {
+    if (err) return cb(err)
+    self.client.token = res.token
+    cb(null, res)
+  })
+}
+
+Auth.prototype.logout = function (cb) {
+  var self = this
+  this.client.request('get', 'auth/logout', function (err, res) {
+    if (err) return cb(err)
+    self.client.token = null
+    cb(null, res)
+  })
+}

--- a/client/index.js
+++ b/client/index.js
@@ -1,0 +1,111 @@
+var qs = require('querystring')
+var request = require('request')
+
+/*
+* Replace AccountsAPIClient with name of your app
+*/
+
+module.exports = AccountsAPIClient
+
+function AccountsAPIClient (options) {
+  if (!(this instanceof AccountsAPIClient)) return new AccountsAPIClient(options)
+  options = options || {}
+
+  this.host = options.host || 'http://127.0.0.1:4243'
+  this.token = null
+
+  this.auth = require('./auth')(this)
+  this.accounts = require('./accounts')(this)
+}
+
+AccountsAPIClient.prototype.request = function (method, path, params, cb) {
+  var options = {}
+
+  if (typeof params === 'function') {
+    cb = params
+    params = {}
+  }
+
+  if (method === 'get') {
+    params = qs.stringify(params)
+    options.uri = this.fullUrl(path, params)
+    options.json = true
+  } else {
+    options.uri = this.fullUrl(path)
+    options.json = options.body = params
+  }
+
+  options.method = method
+
+  if (this.token) {
+    options.headers = {
+      'authorization': 'Bearer ' + this.token
+    }
+  } else {
+    var id = null
+    if (params.username) id = params.username
+    if (params.email) id = params.email
+    if (id && params.password) {
+      options.headers = {
+        'authorization': id + ':' + params.password
+      }
+    }
+  }
+
+  if (typeof cb === 'undefined') return request(options)
+  else request(options, getResponse)
+
+  function getResponse (error, response, body) {
+    if (cb) {
+      if (error) return cb(error)
+      if (response.statusCode >= 400) return cb({ error: { status: response.statusCode } })
+      return cb(null, response, body)
+    }
+  }
+}
+
+AccountsAPIClient.prototype.fullUrl = function fullUrl (path, params) {
+  var url = this.host + '/' + path + '/'
+  if (params) url += '?' + params
+  console.log('url', url)
+  return url
+}
+
+/**
+ * Upload File objects taken from a FileList
+ * @param  {String}   method Must be either `POST` (default) or `PUT`
+ * @param  {String}   path   Path to upload endpoint
+ * @param  {Object}   params Parameters object
+ * @param  {Array}    params.files Array of File objects
+ * @param  {Function} cb     Callback
+ */
+AccountsAPIClient.prototype.upload = function upload (method, path, params, cb) {
+  var url = this.fullUrl(path)
+  var body = new window.FormData()
+
+  params.files.forEach(function (file, index) {
+    body.append(index.toString, file)
+  })
+
+  request({
+    method: method || 'POST',
+    url: url,
+    body: body
+  }, function (err, response, body) {
+    if (err) return cb(err)
+    if (response.statusCode >= 400) return cb({ error: { status: response.statusCode } })
+    return cb(null, response, JSON.parse(body))
+  })
+}
+
+/**
+ * Use this to plug in new handlers
+ * @param {Object} opts Options
+ * @param {String} opts.name Name to use for the new handler
+ * @param {Function} opts.handler The new handler
+ * @api public
+ */
+AccountsAPIClient.prototype.add = function add (opts) {
+  this[opts.name] = opts.handler(this)
+  return this
+}

--- a/examples/create-account.js
+++ b/examples/create-account.js
@@ -1,0 +1,9 @@
+var client = require('../client')({
+  host: 'http://127.0.0.1:4444'
+})
+
+var info = { email: 'ok2@joeblow.com', password: 'o4gnoi4gn' }
+
+client.accounts.create(info, function (err, res, account) {
+  console.log(err, account)
+})

--- a/examples/simple-server.js
+++ b/examples/simple-server.js
@@ -1,0 +1,9 @@
+var http = require('http')
+var memdb = require('memdb')
+var accounts = require('../index')(memdb(), {
+  secret: 'so secret'
+})
+
+http.createServer(function (req, res) {
+  accounts.serve(req, res)
+}).listen(4444)

--- a/index.js
+++ b/index.js
@@ -1,28 +1,21 @@
 var extend = require('extend')
 
-module.exports = function (options) {
+module.exports = function (db, options) {
   options = options || {}
+  var model = require('./model')(db, options)
+  var auth = require('./lib/auth')(options.secret, options)
+  var handler = require('./handler')(model, extend({ auth: auth }, options))
+  var routes = require('./routes')(handler, options)
 
-  return function (server) {
-    if (!server.db) throw new ReferenceError("db is undefined")
-    var secret = options.secret
-    delete options.secret
-
-    var model = require('./model')(server.db, options)
-    var auth = require('./lib/auth')(secret, options)
-    var handler = require('./handler')(model, extend({ auth: auth }, options))
-    var routes = require('./routes')(handler, options)
-
-    return {
-      name: 'accounts',
-      model: model,
-      schema: model.schema,
-      handler: handler,
-      routes: routes,
-      auth: auth,
-      serve: function (req, res) {
-        return routes.match(req, res)
-      }
+  return {
+    name: 'accounts',
+    model: model,
+    schema: model.schema,
+    handler: handler,
+    routes: routes,
+    auth: auth,
+    serve: function (req, res) {
+      return routes.match(req, res)
     }
   }
 }

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,4 +1,3 @@
-var formBody = require('body/form')
 var cookies = require('cookie-cutter')
 
 module.exports = function (secret, options) {
@@ -10,8 +9,7 @@ module.exports = function (secret, options) {
     var authHeader = req.headers.authorization
     if (authHeader && authHeader.indexOf('Bearer') > -1) {
       token = authHeader.split('Bearer ')[1]
-    }
-    else if (req.headers.cookie) {
+    } else if (req.headers.cookie) {
       token = cookies(req.headers.cookie).get('access_token')
     }
     if (token) return this.verifyToken(token, callback)
@@ -28,7 +26,7 @@ module.exports = function (secret, options) {
     return cb(null, token)
   }
 
-  auth.logout = 
+  auth.logout =
   auth.delete = function (res) {
     res.setHeader('Set-Cookie', 'access_token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT')
   }
@@ -38,7 +36,7 @@ module.exports = function (secret, options) {
   }
 
   auth.isPublic = function (obj) {
-    if (obj.value) var obj = obj.value
+    if (obj.value) obj = obj.value
     if (obj.private) return false
     return true
   }
@@ -61,9 +59,9 @@ module.exports = function (secret, options) {
   * example: auth.checkScopes(['read:posts', 'create:posts'], decodedToken)
   */
   auth.checkScopes = function (scopes, decoded) {
-    var i=0
+    var i = 0
     var l = scopes.length
-    for (i; i<l; i++) {
+    for (i; i < l; i++) {
       if (!auth.checkScope(scopes[i], decoded)) return false
     }
     return true

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -9,15 +9,14 @@ function Tokens (secret, opts) {
 }
 
 Tokens.prototype.sign = function (req, payload) {
-  // payload = claims
   var token = jwt.sign(payload, this.secret)
-  req.headers['Authorization'] = "Bearer " + token
+  req.headers['Authorization'] = 'Bearer ' + token
   return token
 }
 
 Tokens.prototype.verify = function (token, cb) {
   if (cb) {
-    if (!token) return cb("Failed to retrieve token from Authorization header")
+    if (!token) return cb('Failed to retrieve token from Authorization header')
     jwt.verify(token, this.secret, cb)
   } else {
     return jwt.verify(token, this.secret)

--- a/model.js
+++ b/model.js
@@ -8,7 +8,7 @@ module.exports = function (db, options) {
     return require('accountdown-basic')(db, prefix, { key: 'key' })
   }
 
-  options.roles = { 
+  options.roles = {
     type: 'object',
     properties: extend({
       admin: { type: ['boolean', 'null'] },
@@ -25,17 +25,17 @@ module.exports = function (db, options) {
         type: 'object',
         properties: {
           type: 'array',
-          items: { type: 'string', enum: ['create', 'read', 'update', 'delete'] },
+          items: { type: 'string', enum: ['create', 'read', 'update', 'delete'] }
         },
         default: { actions: ['read'] }
       }
     }, options.scopes)
   }
 
-  var options = extend({
+  options = extend({
     db: db,
     email: { type: 'string' },
-    username: { type: ['string', 'null']},
+    username: { type: ['string', 'null'] },
     required: ['email'],
     indexKeys: ['email', 'username', 'profile'],
     login: {}

--- a/package.json
+++ b/package.json
@@ -1,13 +1,16 @@
 {
   "name": "accounts-api",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "An accounts api that follows a few contraints to try and make it easy to plug into a node http server",
   "main": "index.js",
   "directories": {
     "test": "tests"
   },
   "scripts": {
-    "test": "tape tests/*.js | tap-spec"
+    "test": "standard && tape tests/*.js | tap-spec"
+  },
+  "browser": {
+    "request": "xhr"
   },
   "repository": {
     "type": "git",
@@ -27,29 +30,29 @@
   "homepage": "https://github.com/LukeSwart/accounts-api",
   "devDependencies": {
     "clone": "^1.0.2",
-    "hammock": "^1.0.2",
-    "memdb": "^1.0.1",
-    "memdown": "^1.0.0",
-    "tap-spec": "^4.0.2",
-    "tape": "^4.0.0"
+    "each-async": "^1.1.1",
+    "hammock": "^1.1.0",
+    "memdb": "^1.3.1",
+    "standard": "^5.4.1",
+    "tap-spec": "^4.1.1",
+    "tape": "^4.4.0"
   },
   "dependencies": {
-    "JSONStream": "^1.0.4",
+    "JSONStream": "^1.0.7",
     "accountdown": "https://github.com/LukeSwart/accountdown/tarball/baa26ddbcd8396019ff45558e103b0b85e04bfea",
     "accountdown-basic": "https://github.com/LukeSwart/accountdown-basic/tarball/e1da72179854f7140a35d66fbdbf8f4b63856fd5",
     "accountdown-model": "^1.1.1",
     "body": "^5.1.0",
     "cookie-cutter": "^0.1.1",
-    "cuid": "^1.2.5",
-    "each-async": "^1.1.1",
+    "cuid": "^1.3.8",
     "extend": "^3.0.0",
-    "filter-object": "^1.1.2",
-    "is-equal": "^1.2.3",
-    "jsonwebtoken": "^5.0.2",
-    "levelup": "^1.2.1",
+    "filter-object": "^2.1.0",
+    "jsonwebtoken": "^5.5.0",
     "match-routes": "^2.0.0",
-    "response": "git://github.com/mikeal/response",
+    "request": "^2.67.0",
+    "response": "^0.18.0",
     "subleveldown": "^2.1.0",
-    "through2": "^2.0.0"
+    "through2": "^2.0.0",
+    "xhr": "^2.2.0"
   }
 }

--- a/routes.js
+++ b/routes.js
@@ -1,6 +1,6 @@
 module.exports = function (handler, options) {
   var router = require('match-routes')()
-  var prefix = options.prefix || '/api/v1'
+  var prefix = options.prefix || ''
 
   router.on(prefix + '/accounts', handler.index.bind(handler))
   router.on(prefix + '/accounts/:key', handler.item.bind(handler))

--- a/tests/auth.js
+++ b/tests/auth.js
@@ -5,7 +5,7 @@ var auth = require('../lib/auth')('test')
 var fixtures = require('./fixtures/auth')
 
 test('private object inaccessible to account without proper role', function (t) {
-  var obj  = fixtures.objects[0]
+  var obj = fixtures.objects[0]
   var account = fixtures.accounts[3]
   t.notOk(auth.isPublic(obj), 'example object is private')
   t.notOk(auth.checkRoles(obj.key, account), 'account does not have access')
@@ -13,7 +13,7 @@ test('private object inaccessible to account without proper role', function (t) 
 })
 
 test('collaborator can access private object if they have object key', function (t) {
-  var obj  = fixtures.objects[0]
+  var obj = fixtures.objects[0]
   var account = fixtures.accounts[2]
   t.notOk(auth.isPublic(obj), 'example object is private')
   t.ok(auth.checkRoles(obj.key, account), 'account has access')
@@ -21,7 +21,7 @@ test('collaborator can access private object if they have object key', function 
 })
 
 test('owner can access private object if they have object key', function (t) {
-  var obj  = fixtures.objects[1]
+  var obj = fixtures.objects[1]
   var account = fixtures.accounts[1]
   t.notOk(auth.isPublic(obj), 'example object is private')
   t.ok(auth.checkRoles(obj.key, account), 'account has access')
@@ -43,7 +43,7 @@ test('admin can access all objects', function (t) {
 })
 
 test('public object is accessible by any account', function (t) {
-  var obj  = fixtures.objects[2]
+  var obj = fixtures.objects[2]
   t.ok(auth.isPublic(obj), 'example object is public')
   t.end()
 })
@@ -78,12 +78,13 @@ test('create accounts model with custom scope', function (t) {
     }
   })
 
-  var data = { 
+  var data = {
     login: { basic: { key: 'o4no34inro34int', password: 'poop' } },
     value: { email: 'cool@example.com', roles: { admin: true } }
   }
 
   accounts.create(data, function (err, account) {
+    t.notOk(err)
     t.ok(account.scopes)
     t.ok(account.scopes.posts)
     t.ok(account.scopes.posts.actions)
@@ -94,7 +95,7 @@ test('create accounts model with custom scope', function (t) {
 })
 
 test('init accounts-api with custom scope', function (t) {
-  var createAccounts = require('../index')({
+  var accounts = require('../index')(memdb(), {
     secret: 'test',
     scopes: {
       posts: {
@@ -110,14 +111,13 @@ test('init accounts-api with custom scope', function (t) {
     }
   })
 
-  var accounts = createAccounts({ db: memdb() })
-
-  var data = { 
+  var data = {
     login: { basic: { key: 'o4no34inro34int', password: 'poop' } },
     value: { email: 'cool@example.com', roles: { admin: true } }
   }
 
   accounts.model.create(data, function (err, account) {
+    t.notOk(err)
     t.ok(account.scopes)
     t.ok(account.scopes.posts)
     t.ok(account.scopes.posts.actions)

--- a/tests/fixtures/accounts.js
+++ b/tests/fixtures/accounts.js
@@ -3,18 +3,18 @@ var cuid = require('cuid')
 module.exports = [
   {
     login: { basic: { key: cuid(), password: 'testPassword' } },
-    value: { username: 'testUsername', email: 'test@example.com'}
+    value: { username: 'testUsername', email: 'test@example.com' }
   },
   {
     login: { basic: { key: cuid(), password: 'example' } },
-    value: { username: 'example', email: 'example@example.com'}
+    value: { username: 'example', email: 'example@example.com' }
   },
   {
     login: { basic: { key: cuid(), password: 'pizza' } },
-    value: { username: 'pizza', email: 'pizza@example.com'}
+    value: { username: 'pizza', email: 'pizza@example.com' }
   },
   {
     login: { basic: { key: cuid(), password: 'poop' } },
-    value: { username: 'poop', email: 'poop@example.com'}
+    value: { username: 'poop', email: 'poop@example.com' }
   }
 ]

--- a/tests/fixtures/auth.js
+++ b/tests/fixtures/auth.js
@@ -59,7 +59,7 @@ module.exports = {
     },
     {
       title: 'public object',
-      key: 'publickey',
+      key: 'publickey'
     }
   ]
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -8,7 +8,7 @@ var accounts = require('../model')(db)
 test('create an account', function (t) {
   var data = {
     login: { basic: { key: cuid(), password: 'test' } },
-    value: { username: 'jane', email: 'jane@example.com'}
+    value: { username: 'jane', email: 'jane@example.com' }
   }
 
   accounts.create(data, function (err, account) {


### PR DESCRIPTION
There are a bunch of changes in here.
## Breaking changes:
- simplified `module.exports` so usage is now:

``` js
var http = require('http')
var memdb = require('memdb')
var accounts = require('accounts-api')(memdb(), {
  secret: 'so secret'
})

http.createServer(function (req, res) {
  accounts.serve(req, res)
}).listen(4444)
```
## Additions:
- an `examples` directory
- api client in the `client` directory
- uses standard style (and added linter to `test` script)

And did a bunch of style cleanup and little fixes.
